### PR TITLE
🐛 Fix. DIY 리소스 포지션 점프 방지 (DDU-206)

### DIFF
--- a/photo_card/lib/ui/child_layer_item.dart
+++ b/photo_card/lib/ui/child_layer_item.dart
@@ -24,10 +24,14 @@ class ChildLayerItem extends StatelessWidget {
         case BackgroundType():
           switch (layerItem.type.background) {
             case Background.gallery:
-              return SizedBox(
-                height: targetSize.height,
-                width: targetSize.width,
-                child: layerItem.object,
+              return OverflowBox(
+                maxHeight: double.infinity,
+                maxWidth: double.infinity,
+                child: SizedBox(
+                  height: targetSize.height,
+                  width: targetSize.width,
+                  child: layerItem.object,
+                ),
               );
             case Background.image:
               return Image(


### PR DESCRIPTION
Why:

- 배경, 스티커 등에서 포지션이 점프하는 문제 발생 (DDU-206)

What:

- ChildLayerItem 수정
- OverflowBox 적용

How:

- targetSize 대신 OverflowBox로 크기 제한
- 최대 크기를 double.infinity로 설정

See: [DDU-206](https://twosun.atlassian.net/browse/DDU-206)

Co-authored-by: 미로[박준영] <miro@twosun.com>